### PR TITLE
Add Windows kernel and Dnsmasq to Recently section

### DIFF
--- a/index.html
+++ b/index.html
@@ -1249,7 +1249,7 @@
 
             <div class="news-item">
                 <div class="news-date">2026.02</div>
-                <div>Found and disclosed vulnerabilities in the <a href="https://github.com/torvalds/linux/commit/f41c5d151078c5348271ffaf8e7410d96f2d82f8" target="_blank">Linux kernel</a>, <a href="https://www.openwall.com/lists/oss-security/2025/12/18/3" target="_blank">Exim</a>, and <a href="https://www.kb.cert.org/vuls/id/458022" target="_blank">Open5GS</a>.</div>
+                <div>Found and disclosed vulnerabilities in the <a href="https://github.com/torvalds/linux/commit/f41c5d151078c5348271ffaf8e7410d96f2d82f8" target="_blank">Linux kernel</a>, <a href="https://msrc.microsoft.com/update-guide/vulnerability/CVE-2026-33841" target="_blank">Windows kernel</a>, <a href="https://www.openwall.com/lists/oss-security/2025/12/18/3" target="_blank">Exim</a>, <a href="https://www.kb.cert.org/vuls/id/471747" target="_blank">Dnsmasq</a>, and <a href="https://www.kb.cert.org/vuls/id/458022" target="_blank">Open5GS</a>.</div>
             </div>
 
             <div class="news-item">

--- a/index.html
+++ b/index.html
@@ -1248,7 +1248,7 @@
             <h2><a href="#recently" style="color: inherit; text-decoration: none;">Recently</a></h2>
 
             <div class="news-item">
-                <div class="news-date">2026.02</div>
+                <div class="news-date">2026.05</div>
                 <div>Found and disclosed vulnerabilities in the <a href="https://github.com/torvalds/linux/commit/f41c5d151078c5348271ffaf8e7410d96f2d82f8" target="_blank">Linux kernel</a>, <a href="https://msrc.microsoft.com/update-guide/vulnerability/CVE-2026-33841" target="_blank">Windows kernel</a>, <a href="https://www.openwall.com/lists/oss-security/2025/12/18/3" target="_blank">Exim</a>, <a href="https://www.kb.cert.org/vuls/id/471747" target="_blank">Dnsmasq</a>, and <a href="https://www.kb.cert.org/vuls/id/458022" target="_blank">Open5GS</a>.</div>
             </div>
 


### PR DESCRIPTION
## Summary
- Add Windows kernel ([CVE-2026-33841](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2026-33841)) and Dnsmasq ([VU#471747](https://www.kb.cert.org/vuls/id/471747), which credits Andrew Fasano by name) to the existing vulnerability disclosure entry in the Recently section.
- Bump the entry date from 2026.02 to 2026.05 to reflect the new disclosures.

## Test plan
- [ ] Open `index.html` locally and confirm the Recently section lists all five projects with working links.
- [ ] Verify the date now reads `2026.05`.

---
_Generated by [Claude Code](https://claude.ai/code/session_0139QeSnUY2hUYduEvwvGNPv)_